### PR TITLE
[WIP] Fix XSLT error when specifying URN in RNG shells

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -26,8 +26,9 @@
     </condition>
   </fail>
   
-  <property name="doctypesDir" location="${dita-ot-dir}/plugins/org.oasis-open.dita.dita13.doctypes/doctypes"/>
-	
+  <!--property name="doctypesDir" location="${dita-ot-dir}/plugins/org.oasis-open.dita.dita13.doctypes/doctypes"/-->
+  <property name="doctypesDir" location="${dita-ot-dir}/plugins/org.oasis-open.dita.v1_3"/>
+  
 	<!-- This is the tools/ dir under the doctypes DIR in the TC-managed
 	     source repository.
 	  -->
@@ -144,7 +145,8 @@
       <include name="saxon9*.jar"/>
     </fileset>
     <fileset dir="${javaLibDir}">
-      <include name="resolver.jar"/>
+      <!--include name="resolver.jar"/-->
+      <include name="xml-resolver-*.jar"/>
     </fileset>
   </path>
 
@@ -229,7 +231,7 @@
       <arg line="generateModules=${doGenerateModules}"/>
       <arg line="generateStandardModules=${doGenerateStandardModules}"/>
       <arg line="generateCatalogs=${doGenerateCatalogs}"/>
-      <arg line="catalogs=&quot;${masterCatalog}&quot;"/>
+      <arg line="catalogUrl=&quot;${catalogPathUrl}&quot;"/>
     </java>        
     
     <antcall target="copy1.3ForeignVocabs"/>
@@ -297,6 +299,7 @@
       <arg line="generateModules=${doGenerateModules}"/>
       <arg line="generateStandardModules=${doGenerateStandardModules}"/>
       <arg line="generateCatalogs=${doGenerateCatalogs}"/>
+      <arg line="catalogUrl=&quot;${catalogPathUrl}&quot;"/>
     </java>        
     
     <antcall target="copy1.3ForeignVocabs"/>
@@ -321,6 +324,7 @@
       <arg line="rootDir=${rngsrcUrl}"/>
       <arg line="generateModules=${doGenerateModules}"/>
       <arg line="generateStandardModules=${doGenerateStandardModules}"/>
+      <arg line="catalogUrl=&quot;${catalogPathUrl}&quot;"/>
     </java>        
   </target>
 
@@ -343,6 +347,7 @@
       <arg line="rootDir=${rngsrcUrl}"/>
       <arg line="generateModules=${doGenerateModules}"/>
       <arg line="generateStandardModules=${doGenerateStandardModules}"/>
+      <arg line="catalogUrl=&quot;${catalogPathUrl}&quot;"/>
     </java>        
   </target>
   
@@ -372,6 +377,7 @@
       <arg line="ditaVersion=${ditaver}"/>
       <arg line="outdir=&quot;${verSpecificOutDir}&quot;"/>
       <arg line="catalogType=${catalogType}"/>
+      <arg line="catalogUrl=&quot;${catalogPathUrl}&quot;"/>
     </java>
   </target>
   

--- a/xsl/lib/catalog_util.xsl
+++ b/xsl/lib/catalog_util.xsl
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+    xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+    xmlns:catu="http://local/catalog-utility"
+    exclude-result-prefixes="xs xd"
+    version="2.0">
+
+    <xd:doc>
+        <xd:desc>DITA-OT Catalog file tree</xd:desc>
+    </xd:doc>
+    <xsl:variable name="catalogTree" as="document-node()">
+        <xsl:document>
+            <xsl:call-template name="expandCatalogFile"/>
+        </xsl:document>
+    </xsl:variable>
+    
+    <xd:doc>
+        <xd:desc>Expand catalog file into temporary tree</xd:desc>
+    </xd:doc>
+    <xsl:template name="expandCatalogFile">
+        <catalog>
+            <xsl:apply-templates select="document($catalogUrl)" mode="MODE_EXPAND_CATALOG">
+                <xsl:with-param name="prmCatalogDir" tunnel="yes" select="$catalogUrl"/>
+            </xsl:apply-templates>
+        </catalog>
+    </xsl:template>
+    
+    <xsl:template match="/" mode="MODE_EXPAND_CATALOG">
+        <xsl:apply-templates select="*" mode="#current"/>
+    </xsl:template>
+    
+    <xsl:template match="cat:*" mode="MODE_EXPAND_CATALOG"/>
+    
+    <xsl:template match="cat:catalog" mode="MODE_EXPAND_CATALOG">
+        <xsl:apply-templates select="*" mode="#current"/>
+    </xsl:template>
+    
+    <xsl:template match="cat:nextCatalog" mode="MODE_EXPAND_CATALOG">
+        <xsl:param name="prmCatalogDir" tunnel="yes" as="xs:string"/>
+        <xsl:variable name="nextCatalog" as="xs:string" select="string(@catalog)"/>
+        <xsl:variable name="fullNextCatalogDir" as="xs:string" select="string(resolve-uri($nextCatalog,$prmCatalogDir))"/>
+        <xsl:apply-templates select="document($nextCatalog,.)" mode="#current">
+            <xsl:with-param name="prmCatalogDir" tunnel="yes" select="$fullNextCatalogDir"/>
+        </xsl:apply-templates>
+    </xsl:template>
+    
+    <xsl:template match="cat:group" mode="MODE_EXPAND_CATALOG">
+        <xsl:apply-templates select="*" mode="#current"/>
+    </xsl:template>
+    
+    <xsl:template match="cat:uri" mode="MODE_EXPAND_CATALOG">
+        <xsl:param name="prmCatalogDir" tunnel="yes" as="xs:string"/>
+        <xsl:variable name="name" select="string(@name)"/>
+        <xsl:variable name="uri" select="string(@uri)"/>
+        <xsl:variable name="fileUri" select="string(resolve-uri($uri,$prmCatalogDir))"/>
+        <uri id="{$name}" uri="{$fileUri}"/>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>Get file URI from URN using catalog file tree</xd:desc>
+        <xd:param>$prmUrn: URN</xd:param>
+        <xd:return>File URI</xd:return>
+    </xd:doc>
+    <xsl:function name="catu:getFileUriFromUrn" as="xs:string">
+        <xsl:param name="prmUrn" as="xs:string"/>
+        <xsl:variable name="fileUri" as="xs:string" select="string(($catalogTree/catalog/uri[string(@id) eq $prmUrn]/@uri)[1])"/>
+        <xsl:choose>
+            <xsl:when test="$fileUri ne ''">
+                <xsl:if test="$debug">
+                    <xsl:message> + [DEBUG] URN="<xsl:value-of select="$prmUrn"/>" is mapped to "<xsl:value-of select="$fileUri"/>"</xsl:message>
+                </xsl:if>
+                <xsl:sequence select="$fileUri"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:message> + [ERROR] URN="<xsl:value-of select="$prmUrn"/>" is not defined in catalog file.</xsl:message>
+                <xsl:sequence select="$prmUrn"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    
+</xsl:stylesheet>

--- a/xsl/lib/relpath_util.xsl
+++ b/xsl/lib/relpath_util.xsl
@@ -378,7 +378,14 @@
          component of the path.
     -->
     <xsl:param name="sourcePath" as="xs:string"/>
-    <xsl:value-of select="tokenize($sourcePath, '/')[last()]"/>
+    <xsl:choose>
+      <xsl:when test="starts-with($sourcePath,'urn:')">
+        <xsl:sequence xmlns:catu="http://local/catalog-utility" select="tokenize(catu:getFileUriFromUrn($sourcePath), '/')[last()]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="tokenize($sourcePath, '/')[last()]"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:function>
   
   <xd:doc xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl">

--- a/xsl/lib/rng2functions.xsl
+++ b/xsl/lib/rng2functions.xsl
@@ -21,6 +21,8 @@
     </xd:desc>
   </xd:doc>
 
+  <xsl:include href="../lib/catalog_util.xsl" />
+
   <xsl:function name="rngfunc:getModuleType" as="xs:string">
     <xsl:param name="rngGrammar" as="element(rng:grammar)"/>
     <xsl:sequence select="rngfunc:getModuleType($rngGrammar, true())"/>
@@ -264,7 +266,15 @@
     <xsl:variable name="result" select="if (document-uri(root($rngGrammar))) 
               then document-uri(root($rngGrammar))
               else $rngGrammar/@origURI"/>
-    <xsl:sequence select="$result"/>
+    <!--xsl:sequence select="$result"/-->
+    <xsl:choose>
+      <xsl:when test="starts-with($result,'urn:')">
+        <xsl:sequence xmlns:catu="http://local/catalog-utility" select="catu:getFileUriFromUrn($result)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="$result"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:function>
   
   <xsl:function name="rngfunc:getDomainsAttValue" as="xs:string?">

--- a/xsl/lib/rng2getReferencedModules.xsl
+++ b/xsl/lib/rng2getReferencedModules.xsl
@@ -38,7 +38,7 @@
     <xsl:choose>
       <xsl:when test="$rngModule">
         <xsl:variable name="gatheredModule" 
-          select="$modulesToProcess[local:isSameModule(string(/*/@origURI),
+          select="$modulesToProcess[local:isSameModule(if (string(/*/@origURI)) then string(/*/@origURI) else string(document-uri(.)),
                string(document-uri($rngModule)))][1]" as="document-node()?"
         />
         <xsl:choose>

--- a/xsl/lib/rng2removeDivs.xsl
+++ b/xsl/lib/rng2removeDivs.xsl
@@ -35,7 +35,17 @@
     <xsl:copy>
       <xsl:if test="$origURI">
     <!--<xsl:message> + [DEBUG] removeDivs: Constructing @origURI attribute</xsl:message>-->
-        <xsl:attribute name="origURI" select="$origURI"/>
+        <!--xsl:attribute name="origURI" select="$origURI"/-->
+        <xsl:attribute name="origURI">
+          <xsl:choose>
+            <xsl:when test="starts-with($origURI,'urn:')">
+              <xsl:value-of xmlns:catu="http://local/catalog-utility" select="catu:getFileUriFromUrn($origURI)"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$origURI"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:attribute>
       </xsl:if>
       <xsl:apply-templates select="@*,node()" mode="#current"/>
     </xsl:copy>

--- a/xsl/rng2catalogs/rng2catalogs.xsl
+++ b/xsl/rng2catalogs/rng2catalogs.xsl
@@ -69,6 +69,11 @@
        
     -->
   
+  <xd:doc>
+    <xd:param>$catalogUrl: File URL of [DITA-OT]/catalog-dita.xml</xd:param>
+  </xd:doc>
+  <xsl:param name="catalogUrl" as="xs:string" required="yes"/>
+  
   <xsl:output omit-xml-declaration="yes"/>
   
   <xsl:template name="processDir">

--- a/xsl/rng2ditadtd/rng2ditadtd.xsl
+++ b/xsl/rng2ditadtd/rng2ditadtd.xsl
@@ -111,6 +111,10 @@
     select="matches($usePublicIDsInShell, 'yes|true|1|on', 'i')"
   />
   
+  <xd:doc>
+    <xd:param>$catalogUrl: File URL of [DITA-OT]/catalog-dita.xml</xd:param>
+  </xd:doc>
+  <xsl:param name="catalogUrl" as="xs:string" required="yes"/>
   
   <!-- NOTE: The primary output of this transform is an XML 
        manifest file that lists all input files and their

--- a/xsl/rng2ditarnc/rng2ditarnc.xsl
+++ b/xsl/rng2ditarnc/rng2ditarnc.xsl
@@ -79,6 +79,11 @@
   <xsl:variable name="doUseURNsInShell" as="xs:boolean"
     select="matches($useURNsInShell, '(yes|true|1|no)', 'i')"
   />
+
+  <xd:doc>
+    <xd:param>$catalogUrl: File URL of [DITA-OT]/catalog-dita.xml</xd:param>
+  </xd:doc>
+  <xsl:param name="catalogUrl" as="xs:string" required="yes"/>
   
   <!-- NOTE: The primary output of this transform is an XML 
        manifest file that lists all input files and their
@@ -148,10 +153,7 @@
       "
     />
     <xsl:variable name="moduleDocs" as="document-node()*"
-      select="for $doc in $rngDocs 
-      return if (matches(string(document-uri($doc)), '.+Mod.rng'))
-      then $doc
-      else ()
+      select="$rngDocs except $shellDocs
       "
     />
     

--- a/xsl/rng2ditaxsd/rng2ditaxsd.xsl
+++ b/xsl/rng2ditaxsd/rng2ditaxsd.xsl
@@ -96,7 +96,12 @@
   <xsl:variable name="doUseURNsInShell" as="xs:boolean"
     select="matches($useURNsInShell, '(yes|true|1|no)', 'i')"
   />
-  
+
+  <xd:doc>
+    <xd:param>$catalogUrl: File URL of [DITA-OT]/catalog-dita.xml</xd:param>
+  </xd:doc>
+  <xsl:param name="catalogUrl" as="xs:string" required="yes"/>
+
   <!-- NOTE: The primary output of this transform is an XML 
        manifest file that lists all input files and their
        corresponding outputs.
@@ -185,7 +190,7 @@
                 return if (matches(string(document-uri($doc)), '.+Mod.rng'))
                           then $doc
                           else ()), 
-                $referencedModules except (rngDocs)
+                $referencedModules except ($rngDocs)
       "
     />
     <xsl:if test="$doDebug">


### PR DESCRIPTION
Avoid XSLT error by reading catalog file directly in the stylesheet.

The main modification:
1. Add catalog manipulation stylesheet "xsl/lib/catalog_util.xsl"
2. Modify build.xml to pass catalog file URL ti every stylesheet.
3. Convert URN obtained by document-uri() function into the file URI in needed portion of stylesheet.

Several other changes:
-  Change doctypesDir to ${dita-ot-dir}/plugins/org.oasis-open.dita.v1_3 to use the newest one.
-  Change resolver.jar file name.
-  Correct the some obvious code error. 

I have tested via my specialization data and confirmed that target "generate-all" ended normally.
However DTD and XSD seems incomplete because opening test DITA instance by oXygen reports the DTD or Scheme error.
I want to test generating OASIS standard DTD/XSD. But as far as I did specifying [DITA-OT]/plugins/org.oasis-open.dita.v1_3 as rngsrc parameter does not succeed by build error.

"D:\My_Documents\Proj\RNGToDTD\dita-rng-converter\build.xml:261: D:\DITA-OT\dita-ot-2.2.3\plugins\org.oasis-open.dita.v1_3\foreign\dtd does not exist."

So currently I have no more means to test this code. This is the background of this pull request 

If you have any problems about this pull request, please let me know.

For your reference I uploaded my test data to the following URL:

[https://onedrive.live.com/redir?resid=941287CBD7F7CB46!6737&authkey=!AMtu9mIlU3XaVLY&ithint=file%2czip](https://onedrive.live.com/redir?resid=941287CBD7F7CB46!6737&authkey=!AMtu9mIlU3XaVLY&ithint=file%2czip)
